### PR TITLE
Fix header html structure error

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -21,10 +21,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <Header />
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Header />
         <main>
           {children}
         </main>


### PR DESCRIPTION
Move `Header` component from `<html>` to `<body>` to resolve hydration error.

---
<a href="https://cursor.com/background-agent?bcId=bc-7646f68c-f915-442b-bba3-b53fdb51eeaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7646f68c-f915-442b-bba3-b53fdb51eeaf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

