### PR TITLE
Fix MDX page to load content on the server

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,30 +1,24 @@
-'use client'
-
-import Card from "@/components/card"
-import fs from "fs"
 import { MDXRemote } from 'next-mdx-remote/rsc'
-import path from "path"
-import { useState } from "react"
+import { notFound } from 'next/navigation'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
-export default function Home({ params }) {
-  const [isVisible, setIsVisible] = useState(true)
-  const [names, setNames] = useState(['Piotr', 'John', 'Terry'])
-  const name = 'Piotr'
-  const handleClick = () => {
-    setIsVisible(!isVisible)
+export default async function Home({ params }) {
+  const slug = params?.slug ?? 'first'
+  const filePath = path.join(process.cwd(), 'src/app/content', `${slug}.mdx`)
+
+  let content = ''
+
+  try {
+    content = await fs.readFile(filePath, 'utf8')
+  } catch (error) {
+    console.error(`Unable to read MDX file for slug "${slug}":`, error)
+    notFound()
   }
-  const handleAdd = () => {
-    setNames([...names, 'New element!'])
-  }
-  const cards = isVisible
-    && names.map((name, index) => <Card key={index}>{name}</Card>)
-  const slug = params?.slug || 'first'
-  const content = fs.readFileSync(path.join(process.cwd(), 'src/app/content', `${slug}.mdx`), 'utf8')
+
   return (
-    <>
-      <article className="prose dark:prose-invert">
-        <MDXRemote source={content} />
-      </article>
-    </>
+    <article className="prose dark:prose-invert">
+      <MDXRemote source={content} />
+    </article>
   )
 }


### PR DESCRIPTION
## Summary
- convert the home page into a server component so that filesystem access happens on the server
- load MDX content via `fs.promises.readFile` and surface a 404 when the file is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85c313ca88331b4b9dd7d0f2d4d9a