### PR TITLE
Add Tailwind-powered dark mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,13 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
 }
 
 body {
-  @apply bg-white text-gray-700 container mx-auto dark:bg-gray-900 dark:text-gray-300 max-w-2xl;
+  @apply container mx-auto max-w-2xl bg-white text-gray-700 transition-colors duration-200 dark:bg-gray-900 dark:text-gray-300;
 }

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -22,7 +22,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={roboto.className}>
         <Header />
         <main className="mt-12">

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,17 +1,19 @@
-import Navigation from "./navigation"
-import Link from "next/link"
+import Navigation from "./navigation";
+import ThemeToggle from "./theme-toggle";
+import Link from "next/link";
 
 export default function Header() {
   return (
     <header className="flex justify-between md:items-center mt-4">
       <div className="flex items-center md:space-x-12">
         <div className="hidden md:block">
-          <Link href="/" className="text-xl">Fabio Ingrasciotta</Link>
+          <Link href="/" className="text-xl">
+            Fabio Ingrasciotta
+          </Link>
         </div>
         <Navigation />
-
       </div>
-      <div> Dark toggle</div>
+      <ThemeToggle />
     </header>
-  )
+  );
 }

--- a/src/components/navigation.module.css
+++ b/src/components/navigation.module.css
@@ -2,7 +2,7 @@
 @reference "tailwindcss";
 
 .link {
-  @apply p-2 text-2xl;
+  @apply rounded-md p-2 text-2xl text-gray-700 transition-colors duration-200 dark:text-gray-200;
 }
 
 @media (min-width: 768px) {
@@ -11,6 +11,11 @@
   }
 }
 
-.link:hover {
-  @apply bg-gray-200 text-gray-700;
+.link:hover,
+.link:focus-visible {
+  @apply bg-gray-200 text-gray-900 dark:bg-gray-800 dark:text-gray-100;
+}
+
+.link:focus-visible {
+  @apply outline-none ring-2 ring-offset-2 ring-gray-400 dark:ring-gray-500;
 }

--- a/src/components/theme-toggle.js
+++ b/src/components/theme-toggle.js
@@ -1,0 +1,92 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const STORAGE_KEY = "theme";
+
+function applyDocumentTheme(theme) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  document.documentElement.classList.toggle("dark", theme === "dark");
+}
+
+function getStoredTheme() {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    return null;
+  }
+}
+
+function storeTheme(theme) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  } catch (error) {
+    // Ignore write errors (e.g. private browsing)
+  }
+}
+
+export default function ThemeToggle({ className = "" }) {
+  const [theme, setTheme] = useState("light");
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    const storedTheme = getStoredTheme();
+    const prefersDark = window.matchMedia
+      ? window.matchMedia("(prefers-color-scheme: dark)").matches
+      : false;
+
+    const initialTheme = storedTheme === "dark" || (!storedTheme && prefersDark)
+      ? "dark"
+      : "light";
+
+    setTheme(initialTheme);
+    applyDocumentTheme(initialTheme);
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+
+    applyDocumentTheme(theme);
+  }, [theme, isMounted]);
+
+  const toggleTheme = () => {
+    if (!isMounted) {
+      return;
+    }
+
+    const nextTheme = theme === "dark" ? "light" : "dark";
+    setTheme(nextTheme);
+    storeTheme(nextTheme);
+  };
+
+  const buttonLabel = theme === "dark" ? "Activate light mode" : "Activate dark mode";
+  const icon = theme === "dark" ? "\u2600\uFE0F" : "\uD83C\uDF19"; // sun / moon icons
+  const text = theme === "dark" ? "Light mode" : "Dark mode";
+
+  const baseClasses = "inline-flex items-center gap-2 rounded-md border border-gray-300 px-3 py-1 text-sm font-medium text-gray-700 transition-colors duration-200 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 dark:border-gray-600 dark:text-gray-200 dark:hover:bg-gray-800 dark:hover:text-gray-100 dark:focus-visible:ring-gray-500";
+  const buttonClasses = className ? `${baseClasses} ${className}` : baseClasses;
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={buttonClasses}
+      aria-label={buttonLabel}
+      aria-pressed={theme === "dark"}
+    >
+      <span aria-hidden="true" className="text-lg">
+        {icon}
+      </span>
+      <span className="hidden md:inline">{text}</span>
+      <span className="md:hidden" aria-hidden="true">
+        {theme === "dark" ? "Light" : "Dark"}
+      </span>
+    </button>
+  );
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,9 @@
+const config = {
+  darkMode: "class",
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx,md,mdx}",
+    "./mdx-components.jsx",
+  ],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add a reusable Tailwind theme toggle button that persists the choice and updates the header
- configure Tailwind for class-based dark mode and refine global/nav styles for dark and light variants
- guard hydration by allowing html class updates while smoothing color transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c86a4707f08331878e908c7752cedd